### PR TITLE
load Zadm::Image on demand

### DIFF
--- a/lib/Zadm/Zone/KVM.pm
+++ b/lib/Zadm/Zone/KVM.pm
@@ -342,7 +342,7 @@ sub install($self) {
     }
 
     if ($check !~ /^no?$/i) {
-        $self->utils->zfsRecv($img->{_file}, $self->bootdisk->{path});
+        $self->zones->image->zfsRecv($img->{_file}, $self->bootdisk->{path});
         # TODO: '-x volsize' for zfs recv seems not to work so we must reset the
         # volsize to the original value after receive
         $self->utils->exec('zfs', [ 'set', 'volsize=' . $self->bootdisk->{size}, $self->bootdisk->{path} ]);

--- a/lib/Zadm/Zone/base.pm
+++ b/lib/Zadm/Zone/base.pm
@@ -13,7 +13,6 @@ use Storable qw(freeze);
 use Term::ANSIColor qw(colored);
 use Zadm::Zones;
 use Zadm::Utils;
-use Zadm::Image;
 use Zadm::Validator;
 
 # constants/definitions
@@ -314,7 +313,6 @@ $genDoc = sub($schema, $over = 0) {
 has log     => sub { Mojo::Log->new(level => 'debug') };
 has zones   => sub($self) { Zadm::Zones->new(log => $self->log) };
 has utils   => sub($self) { Zadm::Utils->new(log => $self->log) };
-has image   => sub($self) { Zadm::Image->new(log => $self->log) };
 has sv      => sub($self) { Zadm::Validator->new(log => $self->log) };
 has dp      => sub($self) { Data::Processor->new($self->schema) };
 has name    => sub { Mojo::Exception->throw("ERROR: zone name must be specified on instantiation.\n") };


### PR DESCRIPTION
before:
```
hadfl@nemesis:/build/zadm$ PERL5LIB=/build/zadm/lib:/build/zadm/thirdparty/lib/perl5 thirdparty/bin/pmcost Zadm::Zones

# Start stats from Devel::EndStats:
# Program runtime duration: 322.889ms
# Total number of required files loaded: 181
# Total number of required lines loaded: 114280
# Seq  Lines  Load Time         Module
#   1    293   321.991ms( 99%)    Zadm/Zones.pm (loaded by main)
```

now:
```
hadfl@nemesis:/build/zadm$ PERL5LIB=/build/zadm/lib:/build/zadm/thirdparty/lib/perl5 thirdparty/bin/pmcost Zadm::Zones

# Start stats from Devel::EndStats:
# Program runtime duration: 246.937ms
# Total number of required files loaded: 121
# Total number of required lines loaded: 87906
# Seq  Lines  Load Time         Module
#   1    301   246.241ms( 99%)    Zadm/Zones.pm (loaded by main)
```