### PR TITLE
Update image not found error.

### DIFF
--- a/lib/Zadm/Image.pm
+++ b/lib/Zadm/Image.pm
@@ -59,7 +59,7 @@ has metadata => sub($self) {
         }
     }
 
-    @imgs < 1 and Mojo::Exception->throw("ERROR: image UUID containing '$uuid' not found.\n");
+    @imgs < 1 and Mojo::Exception->throw("ERROR: image UUID containing '$uuid' not found for brand '$brand'.\n");
     @imgs > 1 and Mojo::Exception->throw("ERROR: more than one image UUID contains '$uuid'.\n");
 
     my $img = $imgs[0];


### PR DESCRIPTION
```
phoenix@phoenix:~$ EDITOR=nano pfexec zadm create -b bhyve -i f44cca19 lx_as_bhyve
You did not make any changes to the default configuration,
do you want to create the zone with all defaults [Y/n]? 
ERROR: image UUID containing 'f44cca19' not found.
phoenix@phoenix:~$ EDITOR=nano pfexec zadm create -b lx -i f44cca19 lx_as_lx
You did not make any changes to the default configuration,
do you want to create the zone with all defaults [Y/n]? 
Downloading http://download.proxmox.com/images/system/ubuntu-20.10-standard_20.10-1_amd64.tar.gz...
  9MiB/211MiB 01:00:05 [  1.8MiB/s] [ETA: 01:01:49]^C
phoenix@phoenix:~$ 
```
The image not found error is printed when an image exists but the incorrect brand has been specified. This updates the message slightly to help clarify.